### PR TITLE
Various improvements and bugfixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-15, macos-14, macos-13, macos-12]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-15, macos-14, macos-13]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ The format is based on [Keep a Changelog][kac] and this project adheres to [Sema
 [kac]: https://keepachangelog.com/
 [semver]: https://semver.org/
 
+### [v0.4.1](https://github.com/sengaya/aws-micro-cli/releases/tag/v0.4.1) - 2024-11-05
+
+#### Changed
+
+- Improved `date` detection
+- Improved argument handling
+- Removed macos-12 from GitHub Actions as it will soon be deprecated
+
+#### Fixed
+
+- Use `~` instead of `$HOME`. The latter would result in an error in environments like AWS Lambda where `$HOME` is not set
+- Return correct version
+
 ### [v0.4.0](https://github.com/sengaya/aws-micro-cli/releases/tag/v0.4.0) - 2024-11-01
 
 #### Added

--- a/args.sh
+++ b/args.sh
@@ -5,6 +5,14 @@ die() {
   exit "${_ret}"
 }
 
+check_argument() {
+  if [[ "$1" == -* ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 print_long_help() {
   echo "AWS-MICRO()                                                        AWS-MICRO()
 
@@ -129,42 +137,42 @@ bucket-owner-full-control                | log-delivery-write" 1
         acl_header="x-amz-acl:${_arg_acl}"
         ;;
       --content-type)
-        test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+        test $# -lt 2 || check_argument "$2" && die "Missing value for the optional argument '$_key'." 1
         _arg_content_type="$2"
         shift
         ;;
       --bucket)
-        test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+        test $# -lt 2 || check_argument "$2" && die "Missing value for the optional argument '$_key'." 1
         _arg_bucket="$2"
         shift
         ;;
       --endpoint-url)
-        test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+        test $# -lt 2 || check_argument "$2" && die "Missing value for the optional argument '$_key'." 1
         _arg_endpoint_url="$2"
         shift
         ;;
       --key)
-        test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+        test $# -lt 2 || check_argument "$2" && die "Missing value for the optional argument '$_key'." 1
         _arg_key="$2"
         shift
         ;;
       --profile)
-        test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+        test $# -lt 2 || check_argument "$2" && die "Missing value for the optional argument '$_key'." 1
         _arg_profile="$2"
         shift
         ;;
       --region)
-        test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+        test $# -lt 2 || check_argument "$2" && die "Missing value for the optional argument '$_key'." 1
         region="$2"
         shift
         ;;
       --role-arn)
-        test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+        test $# -lt 2 || check_argument "$2" && die "Missing value for the optional argument '$_key'." 1
         _arg_role_arn="$2"
         shift
         ;;
       --role-session-name)
-        test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+        test $# -lt 2 || check_argument "$2" && die "Missing value for the optional argument '$_key'." 1
         _arg_role_session_name="$2"
         shift
         ;;
@@ -240,6 +248,6 @@ get_args() {
     region="${AWS_DEFAULT_REGION:-}"
   fi
   if [[ -z "${AWS_CONFIG_FILE:-}" ]]; then
-    AWS_CONFIG_FILE="$HOME/.aws/config"
+    AWS_CONFIG_FILE=~"/.aws/config"
   fi
 }


### PR DESCRIPTION
- Improved `date` detection
- Improved argument handling
- Removed macos-12 from GitHub Actions as it will soon be deprecated
- Use `~` instead of `$HOME`. The latter would result in an error in environments like AWS Lambda where `$HOME` is not set
- Return correct version